### PR TITLE
fix: group names support dynamic appended value

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -2,6 +2,10 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at http://oss.oracle.com/licenses/upl.
 #
 
+resource "random_id" "groups" {
+  byte_length = 2
+}
+
 #*************************************
 #           Groups
 #*************************************
@@ -11,7 +15,7 @@ resource "oci_identity_group" "ods-group" {
   provider       = oci.home
   compartment_id = var.tenancy_ocid
   description    = "Data Science Group"
-  name           = var.ods_group_name
+  name           = local.ods_group_name
   
   lifecycle {
     ignore_changes = [ defined_tags["Oracle-Tags.CreatedBy"], defined_tags["Oracle-Tags.CreatedOn"] ]
@@ -29,7 +33,7 @@ resource "oci_identity_dynamic_group" "ods-dynamic-group" {
   provider = oci.home
   compartment_id = var.tenancy_ocid
   description = "Data Science Dynamic Group"
-  name = var.ods_dynamic_group_name
+  name = local.ods_dynamic_group_name
   matching_rule = "any {all {resource.type='fnfunc',resource.compartment.id='${var.compartment_ocid}'}, all {resource.type='ApiGateway',resource.compartment.id='${var.compartment_ocid}'}, all {resource.type='datasciencenotebooksession',resource.compartment.id='${var.compartment_ocid}'} }"
   
   lifecycle {
@@ -49,20 +53,25 @@ resource "oci_identity_policy" "ods-policy" {
   compartment_id = var.compartment_ocid
   description    = "Data Science Policies"
   name           = var.ods_policy_name
+  depends_on = [
+    oci_identity_group.ods-group,
+    oci_identity_dynamic_group.ods-dynamic-group,
+    oci_identity_tag_namespace.devrel
+  ]
   
   statements = [
-    "Allow group ${var.ods_group_name} to manage data-science-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
-    "Allow group ${var.ods_group_name} to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
-    "Allow group ${var.ods_group_name} to manage functions-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow group ${local.ods_group_name} to manage data-science-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
+    "Allow group ${local.ods_group_name} to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
+    "Allow group ${local.ods_group_name} to manage functions-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
     "Allow service datascience to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
     "Allow service FaaS to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
-    "Allow dynamic-group ${oci_identity_dynamic_group.ods-dynamic-group.name} to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
-    "Allow dynamic-group ${oci_identity_dynamic_group.ods-dynamic-group.name} to use functions-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
-    "Allow dynamic-group ${oci_identity_dynamic_group.ods-dynamic-group.name} to manage data-science-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
-    "Allow dynamic-group ${oci_identity_dynamic_group.ods-dynamic-group.name} to manage objects ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
-    "Allow dynamic-group ${oci_identity_dynamic_group.ods-dynamic-group.name} to manage dataflow-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow dynamic-group ${local.ods_dynamic_group_name} to use virtual-network-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow dynamic-group ${local.ods_dynamic_group_name} to use functions-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow dynamic-group ${local.ods_dynamic_group_name} to manage data-science-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow dynamic-group ${local.ods_dynamic_group_name} to manage objects ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
+    "Allow dynamic-group ${local.ods_dynamic_group_name} to manage dataflow-family ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}" }" ,
     "Allow service FaaS to read repos ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
-    "Allow group ${var.ods_group_name} to manage repos ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
+    "Allow group ${local.ods_group_name} to manage repos ${data.oci_identity_compartment.current_compartment.id == var.tenancy_ocid ? "in tenancy" : "in compartment ${data.oci_identity_compartment.current_compartment.name}"}",
   ]
   
   lifecycle {

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -14,6 +14,7 @@ variableGroups:
       - fingerprint
       - private_key_path
       - private_key_password
+      - private_key
       - ${region}
       - ${compartment_ocid}
     visible: false
@@ -21,18 +22,16 @@ variableGroups:
     variables:
       - ${create_ods_group}
       - ${ods_group_name}
+      - ${ods_group_name_randomized}
       - ${ods_dynamic_group_name}
+      - ${ods_dynamic_group_name_randomized}
       - ${ods_policy_name}
-      # - ${ods_root_policy_name}
   - title: "Network Configuration"
     variables:
       - ${ods_vcn_use_existing}
       - ${ods_vcn_existing}
       - ${ods_vcn_name}
       - ${ods_vcn_cidr}
-      # - ${ods_subnet_public_existing}
-      # - ${ods_subnet_public_name}
-      # - ${ods_subnet_public_cidr}
       - ${ods_subnet_private_existing}
       - ${ods_subnet_private_name}
       - ${ods_subnet_private_cidr}
@@ -44,15 +43,6 @@ variableGroups:
       - ${ods_compute_shape}
       - ${ods_storage_size}
       - ${ods_number_of_notebooks}
-      # - ${functions_enabled}
-  # - title: "Vault Configuration"
-  #   variables:
-  #     - ${enable_vault}
-  #     - ${ods_vault_name}
-  #     - ${ods_vault_type}
-  #     - ${enable_create_vault_master_key}
-  #     - ${ods_vault_master_key_name}
-  #     - ${ods_vault_master_key_length}
   - title: "Functions/API Gateway Configuration"
     variables:
       - ${enable_functions}
@@ -189,7 +179,7 @@ variables:
   create_ods_group:
     type: boolean
     title: "Should a group be created?"
-    description: "True = yes, create a new group.  False = use an existing group (do not create a group)."
+    description: "To use an existing group, uncheck this setting and provide the group name in 'Group Name for security policies'"
     required: true
     default: true
   ods_group_name:
@@ -206,6 +196,16 @@ variables:
     required: true
     default: "DataScienceDynamicGroup"
     pattern: "^[a-zA-Z0-9_-]+$"
+  ods_group_name_randomized:
+    type: boolean
+    title: "Append random characters to ODS group name?"
+    required: true
+    default: true
+  ods_dynamic_group_name_randomized:
+    type: boolean
+    title: "Append random characters to the ODS dynamic group name?"
+    required: true
+    default: true
   ods_policy_name:
     type: string
     title: "Policy Name (Compartment Level)"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,9 +100,19 @@ variable "ods_group_name" {
   default = "DataScienceGroup"
   description = "ODS IAM Group Name (no spaces)"
 }
+variable "ods_group_name_randomized" {
+  type    = bool
+  default = true
+  description = "Whether or not randomized characters should be appended to the group name"
+}
 variable "ods_dynamic_group_name" {
   default = "DataScienceDynamicGroup"
   description = "ODS IAM Dynamic Group Name (no spaces)"
+}
+variable "ods_dynamic_group_name_randomized" {
+  type    = bool
+  default = true
+  description = "Whether or not randomized characters should be appended to the dynamic group name"
 }
 variable "ods_policy_name" {
   default = "DataSciencePolicies"
@@ -151,4 +161,6 @@ locals {
   private_subnet_id = var.ods_vcn_use_existing ? var.ods_subnet_private_existing : oci_core_subnet.ods-private-subnet[0].id
   private_key = try(file(var.private_key_path), var.private_key)
   release = "1.0"
+  ods_group_name = var.ods_group_name_randomized ? "${var.ods_group_name}_${random_id.groups.hex}" : var.ods_group_name
+  ods_dynamic_group_name = var.ods_dynamic_group_name_randomized ? "${var.ods_dynamic_group_name}_${random_id.groups.hex}" : var.ods_dynamic_group_name
 }


### PR DESCRIPTION
Fixing situations where the group name and/or dynamic group name creation would fail, if it already existed.  This might occur in situations where the HoL would be deployed more than once in the same tenancy.  This eliminates the potential for collision with the same group names being used.