### PR TITLE
automatically set the latest Oracle Linux 7.9 image build number as default OS image

### DIFF
--- a/terraform/computes.tf
+++ b/terraform/computes.tf
@@ -27,7 +27,7 @@ resource oci_core_instance redbull_lab1 {
   }
   
   source_details {
-    source_id = local.list_images[var.compute_image_name].id
+    source_id = local.list_images[var.compute_image_name==""?data.oci_core_images.ol79.images.0.display_name:var.compute_image_name].id
     source_type = "image"
   }
   

--- a/terraform/data_sources.tf
+++ b/terraform/data_sources.tf
@@ -43,3 +43,18 @@ data "oci_core_images" "this" {
     values = ["AVAILABLE"]
   }
 }
+
+data "oci_core_images" "ol79" {
+  compartment_id = var.compartment_ocid
+  operating_system = "Oracle Linux"
+  filter {
+    name = "display_name"
+    values = ["^Oracle-Linux-7.9-([\\.0-9-]+)$"]
+    regex = true
+  }
+}
+
+output "OS_version" {
+  description = "Oracle Linux version"
+  value       = data.oci_core_images.ol79.images.0.display_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,5 +62,5 @@ variable "private_key_password" {
 variable "compute_image_name" {
   type = string
   description = "The name of the compute image to use for the compute instances."
-  default = "Oracle-Linux-7.9-2021.08.27-0"
+  default = ""
 }


### PR DESCRIPTION
close #39 